### PR TITLE
fix: routing for ssr

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,4 +1,4 @@
-ARG NODE_VERSION=16
+ARG NODE_VERSION=18
 ARG SERVER_PORT=3001
 
 FROM node:$NODE_VERSION-buster as base
@@ -13,7 +13,7 @@ RUN yarn install --frozen-lockfile
 COPY . .
 
 RUN yarn lerna bootstrap
-RUN rm -rf /app/packages/server/dist/ && yarn build --scope=server
+RUN rm -rf /app/packages/server/dist/ && yarn build
 
 
 FROM node:$NODE_VERSION-buster-slim as production
@@ -21,7 +21,9 @@ WORKDIR /app
 
 COPY --from=builder /app/packages/server/dist/ /app/
 COPY --from=builder /app/packages/server/package.json /app/package.json
+COPY --from=builder /app/packages/client/ /client/
 RUN yarn install --production=true
+RUN yarn add vite
 
 EXPOSE $SERVER_PORT
 CMD [ "node", "/app/index.js" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,6 @@
 version: "3.9"
 
 services:
-    client:
-        container_name: prakticum-client
-        image: prakticum-client
-        build:
-            context: .
-            dockerfile: Dockerfile.client
-            args:
-              CLIENT_PORT: ${CLIENT_PORT}
-        restart: always
-        ports:
-            - "${CLIENT_PORT}:80"
-        environment:
-          - CLIENT_PORT=${CLIENT_PORT}
-          - SERVER_PORT=${SERVER_PORT}
     server:
         container_name: prakticum-server
         image: prackicum-server

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -5,8 +5,9 @@
   "license": "MIT",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build --config vite.config.ts",
     "build:ssr": "tsc && vite build --config ssr.config.ts",
+    "build:client": "tsc && vite build --config vite.config.ts",
+    "build": "yarn build:ssr && yarn build:client",
     "preview": "vite preview",
     "lint": "eslint ./src",
     "stylelint": "stylelint ./src/**/*.css",
@@ -28,7 +29,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",
-    "react-router-dom": "^6.4.4",
+    "react-router-dom": "^6.6.2",
     "redux": "^4.2.0",
     "yup": "^0.32.11"
   },

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -1,13 +1,16 @@
 import { Provider } from 'react-redux';
-import { RouterProvider } from 'react-router-dom';
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 
 import store from './store/store';
-import { ROUTER } from './utils/routes';
+import { routes } from './utils/routes';
 
 export default function App() {
+
+  const router = createBrowserRouter(routes);
+
   return (
     <Provider store={store}>
-      <RouterProvider router={ROUTER} />
+      <RouterProvider router={router} />
     </Provider>
   );
 }

--- a/packages/client/src/utils/routes.tsx
+++ b/packages/client/src/utils/routes.tsx
@@ -1,5 +1,3 @@
-import { createBrowserRouter, type NonIndexRouteObject } from 'react-router-dom';
-
 import Forum from '../pages/Forum';
 import ForumPage from '../pages/ForumPage';
 import Game from '../pages/Game';
@@ -18,12 +16,12 @@ export enum RoutePaths {
   forumPage = 'forum/:postId',
 }
 
-const forumPage: NonIndexRouteObject = {
+const forumPage = {
   path: RoutePaths.forumPage,
   element: <ForumPage />,
 };
 
-const children: NonIndexRouteObject[] = [
+const children = [
   {
     path: RoutePaths.login,
     element: <Login />,
@@ -51,7 +49,7 @@ const children: NonIndexRouteObject[] = [
 /**
  * Root page
  */
-const ROOT: NonIndexRouteObject = {
+const ROOT = {
   path: RoutePaths.root,
   element: <Root />,
   children,
@@ -78,4 +76,4 @@ export const UNAUTHORIZED_ROUTES = {
   ],
 };
 
-export const ROUTER = createBrowserRouter([ROOT]);
+export const routes = [ROOT];

--- a/packages/client/ssr.tsx
+++ b/packages/client/ssr.tsx
@@ -1,13 +1,82 @@
+import { createStaticHandler } from '@remix-run/router';
+import type * as express from 'express';
+import * as React from 'react';
 import { renderToString } from 'react-dom/server';
 import { Provider } from 'react-redux';
+import {
+  createStaticRouter,
+  StaticRouterProvider,
+} from 'react-router-dom/server';
 
-import Root from './src/pages/Root';
 import store from './src/store/store';
+import { routes } from './src/utils/routes';
 
-export function render() {
+/*
+Note: implementation is based on the following example from react-router repo.
+https://github.com/remix-run/react-router/blob/main/examples/ssr-data-router/src/entry.server.tsx
+*/
+
+export async function render(request: express.Request) {
+  const { query } = createStaticHandler(routes);
+  const remixRequest = createFetchRequest(request);
+  const context = await query(remixRequest);
+
+  if (context instanceof Response) {
+    throw context;
+  }
+
+  const router = createStaticRouter(routes, context);
+
   return renderToString(
     <Provider store={store}>
-      <Root />
+      <StaticRouterProvider
+        router={router}
+        context={context}
+        nonce="the-nonce"
+      />
     </Provider>
   );
+}
+
+export function createFetchHeaders(
+  requestHeaders: express.Request['headers']
+): Headers {
+  const headers = new Headers();
+
+  for (const [key, values] of Object.entries(requestHeaders)) {
+    if (values) {
+      if (Array.isArray(values)) {
+        for (const value of values) {
+          headers.append(key, value);
+        }
+      } else {
+        headers.set(key, values);
+      }
+    }
+  }
+
+  return headers;
+}
+
+export function createFetchRequest(req: express.Request): Request {
+  const origin = `${req.protocol}://${req.get('host')}`;
+  const url = new URL(req.originalUrl || req.url, origin);
+
+  const controller = new AbortController();
+
+  req.on('close', () => {
+    controller.abort();
+  });
+
+  const init: RequestInit = {
+    method: req.method,
+    headers: createFetchHeaders(req.headers),
+    signal: controller.signal,
+  };
+
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    init.body = req.body;
+  }
+
+  return new Request(url.href, init);
 }

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -57,6 +57,7 @@ async function startServer() {
 
     try {
       let template: string;
+      let render: (request: express.Request) => Promise<string>;
 
       if (!isDev()) {
         template = fs.readFileSync(
@@ -69,8 +70,6 @@ async function startServer() {
         template = await vite!.transformIndexHtml(url, template);
       }
 
-      let render: () => Promise<string>;
-
       if (!isDev()) {
         render = (await import(ssrClientPath)).render;
       } else {
@@ -78,7 +77,7 @@ async function startServer() {
           .render;
       }
 
-      const appHtml = await render();
+      const appHtml = await render(req);
 
       const html = template.replace('<!--ssr-outlet-->', appHtml);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1939,10 +1939,10 @@
     redux-thunk "^2.4.2"
     reselect "^4.1.7"
 
-"@remix-run/router@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.1.0.tgz#b48db8148c8a888e50580a8152b6f68161c49406"
-  integrity sha512-rGl+jH/7x1KBCQScz9p54p0dtPLNeKGb3e0wD2H5/oZj41bwQUnXdzbj2TbUAFhvD7cp9EyEQA4dEgpUFa1O7Q==
+"@remix-run/router@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.3.1.tgz#3bb0b6ddc0a276e8dc1138d08f63035e4e23e8bf"
+  integrity sha512-+eun1Wtf72RNRSqgU7qM2AMX/oHp+dnx7BHk1qhK5ZHzdHTUU4LA1mGG1vT+jMc8sbhG3orvsfOmryjzx2PzQw==
 
 "@sinclair/typebox@^0.24.1":
   version "0.24.51"
@@ -7550,20 +7550,20 @@ react-refresh@^0.14.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.0.tgz#4e02825378a5f227079554d4284889354e5f553e"
   integrity sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==
 
-react-router-dom@^6.4.4:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.5.0.tgz#3970bdcaa7c710a6e0b478a833ba0b4b8ae61a6f"
-  integrity sha512-/XzRc5fq80gW1ctiIGilyKFZC/j4kfe75uivMsTChFbkvrK4ZrF3P3cGIc1f/SSkQ4JiJozPrf+AwUHHWVehVg==
+react-router-dom@^6.6.2:
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.8.0.tgz#5e5f4c4b15fdec3965d2ad9d7460d0c61971e744"
+  integrity sha512-hQouduSTywGJndE86CXJ2h7YEy4HYC6C/uh19etM+79FfQ6cFFFHnHyDlzO4Pq0eBUI96E4qVE5yUjA00yJZGQ==
   dependencies:
-    "@remix-run/router" "1.1.0"
-    react-router "6.5.0"
+    "@remix-run/router" "1.3.1"
+    react-router "6.8.0"
 
-react-router@6.5.0:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.5.0.tgz#b53f15543a60750c925609d2e38037ac5aed6dd3"
-  integrity sha512-fqqUSU0NC0tSX0sZbyuxzuAzvGqbjiZItBQnyicWlOUmzhAU8YuLgRbaCL2hf3sJdtRy4LP/WBrWtARkMvdGPQ==
+react-router@6.8.0:
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.8.0.tgz#dd61fd1ec44daa2cceaef8e6baa00f99a01a650f"
+  integrity sha512-760bk7y3QwabduExtudhWbd88IBbuD1YfwzpuDUAlJUJ7laIIcqhMvdhSVh1Fur1PE8cGl84L0dxhR3/gvHF7A==
   dependencies:
-    "@remix-run/router" "1.1.0"
+    "@remix-run/router" "1.3.1"
 
 react-transition-group@^4.4.5:
   version "4.4.5"


### PR DESCRIPTION
Обновила роутинг для ssr на StaticRouterProvider по примеру из react-router репозитория. Ссылка: [ssr-data-router example](https://github.com/remix-run/react-router/blob/main/examples/ssr-data-router/src/entry.server.tsx)

Добавила команду `build:client` в package.json клиента, чтобы можно было собирать одной командой `yarn build`.

Обновила версию пакета `react-router-dom`, т.к. в версии 6.4 реализация `createStaticHandler` была помечена, как unstable.

Запускать нужно на версии `node >= 18`