### PR TITLE
fix: ssr config variables

### DIFF
--- a/packages/client/ssr.config.ts
+++ b/packages/client/ssr.config.ts
@@ -13,6 +13,10 @@ export default defineConfig({
   ssr: {
     format: 'cjs',
   },
+  define: {
+    __SERVER_PORT__: process.env.SERVER_PORT || 3001,
+    __API_SERVER_HOST__: `'${process.env.SERVER_HOST}'` || '',
+  },
   build: {
     ssr: true,
     lib: {

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   },
   define: {
     __SERVER_PORT__: process.env.SERVER_PORT || 3001,
-    __API_SERVER_HOST__: `'${process.env.SERVER_HOST}'`,
+    __API_SERVER_HOST__: `'${process.env.SERVER_HOST}'` || '',
   },
   resolve: {
     alias: {


### PR DESCRIPTION
### Какую задачу решаем
vite.config файлик не подбирается для prod сборки  (для SSR). Пробросила все эти определения для конфига в SSR.